### PR TITLE
Added code to reuse default locations and make sure only valid regions are used

### DIFF
--- a/azd/scripts/preprovision.ps1
+++ b/azd/scripts/preprovision.ps1
@@ -1,12 +1,76 @@
+<#
+.SYNOPSIS
+Sets the location for the Azure resource group for the current azd environment.
+
+.DESCRIPTION
+The `Set-ResourceGroupLocation` function prompts the user to enter a location for the Azure resource group. If a default location is provided, the user can press ENTER to use the default value. The function validates the entered location against a list of available Azure regions and sets the environment variable for the resource group location if the entered location is valid.
+
+.PARAMETER envVarName
+The name of the environment variable to set for the resource group location.
+
+.PARAMETER resourceAlias
+A descriptive alias for the type of resources being set (e.g., "Vision", "Document Intelligence").
+
+.PARAMETER availableRegions
+An array of available Azure regions to validate the entered location against. This can be retrieved using the `az account list-locations` command.
+
+.PARAMETER defaultLocation
+The default location to use if the user does not provide a new location.
+
+.EXAMPLE
+Set-ResourceGroupLocation -envVarName "RESOURCE_GROUP_LOCATION" -resourceAlias "resource group" -availableRegions $availableRegions -defaultLocation $defaultLocation
+
+This example sets the location for the resource group using the provided environment variable name, location alias, available regions, and default location.
+
+.NOTES
+- The function will prompt the user to enter a location if the default location is not set.
+- The function will loop until a valid Azure region is entered.
+- The function sets the specified environment variable to the valid location entered by the user.
+#>
+function Set-ResourceGroupLocation {
+       param (
+              [string]$envVarName,
+              [string]$resourceAlias,
+              [string[]]$availableRegions,
+              [string]$defaultLocation
+       )
+
+       while ($true) {
+              # Check if the default location is already set
+              if ($defaultLocation) {
+                     $location = Read-Host "Please enter the location for your $resourceAlias resources (or press ENTER to use the default value: $defaultLocation)"
+                     
+                     # Use the current value if the user presses ENTER
+                     if ([string]::IsNullOrWhiteSpace($location)) {
+                            $location = $defaultLocation
+                     }
+              }
+              else {
+                     # Default location is not set
+                     $location = Read-Host "Please enter the location for your $resourceAlias resources"
+              }
+              # Check if the entered location is valid
+              if ($availableRegions -contains $location) {
+                     azd env set $envVarName $location
+                     break
+              }
+              else {
+                     Write-Host "Invalid Azure region: $location" -ForegroundColor Red
+                     Write-Host "Available regions are: $availableRegions" -ForegroundColor Yellow
+              }
+       }
+}
+
+# Main script logic
 Write-Host "IMPORTANT! `nIf you previously deployed the Vision demo, you must delete the soft-deleted AML Workspace to avoid conflicts." -ForegroundColor Magenta
 Write-Host "Ensure that any relevant soft-deleted AML Workspaces have been permanently deleted before continuing. `nazd down does NOT permanently delete AML Workspaces." -ForegroundColor Magenta
-Read-Host "Press ENTER to continue..."
+Read-Host "Press ENTER to continue or CTRL+C to cancel..."
 
 Write-Host "Running pre-provision script..."
 # Get object ID of the current user if the env var is not already set
 if (-not $env:YOUR_OBJECT_ID) {
        $UserObjectId = az ad signed-in-user show --query id -o tsv
-       if(-not $UserObjectId) {
+       if (-not $UserObjectId) {
               Write-Host "Unable to obtain your Entra ID user object ID." -ForegroundColor Red
               $UserObjectId = Read-Host "Please enter your Object ID and press ENTER"
        }
@@ -23,14 +87,44 @@ if (-not $env:YOUR_OBJECT_ID) {
 $MultiResourceGroup = "multi-${env:AZURE_ENV_NAME}-rg"
 azd env set MULTI_RESOURCE_GROUP $MultiResourceGroup
 
+# List of available Azure regions
+Write-Host "Getting a list of available Azure regions..."
+$availableRegions = az account list-locations --query "[].name" -o tsv
+
+# Ensure the DEFAULT_LOCATION environment variable is set
+if (-not $env:DEFAULT_LOCATION) {
+       # Check if AZURE_LOCATION environment variable (as part of 'azd up')
+       if ($env:AZURE_LOCATION) {
+              $defaultLocation = Read-Host "Please enter the default location for your resources (or press ENTER to use the Azure location value: $($env:AZURE_LOCATION))"
+       
+              # Use the AZURE_LOCATION value if the user presses ENTER
+              if ([string]::IsNullOrWhiteSpace($defaultLocation)) {
+                     $defaultLocation = $env:AZURE_LOCATION
+              }
+       }
+       else {
+              # Azure location is not set
+              $defaultLocation = Read-Host "Please enter the default location for your resources"
+       }
+       
+       # Check if the entered location is valid
+       if (-not($availableRegions -contains $defaultLocation)) {
+              Write-Host "Invalid Azure region: $defaultLocation" -ForegroundColor Red
+              Write-Host "Available regions are: $availableRegions" -ForegroundColor Yellow
+              # Ask the user to enter the location again
+              $defaultLocation = Read-Host "Please enter a valid default location for your resources"
+       }
+       # Set the DEFAULT_LOCATION environment variable
+       azd env set DEFAULT_LOCATION $defaultLocation
+}
+else {
+       # If DEFAULT_LOCATION environment variable is set, store it in a variable
+       $defaultLocation = $env:DEFAULT_LOCATION
+}
+
+# Provision all demos or ask the user which demos to provision
 $ProvisionAllDemos = Read-Host "Provision all demos? (y/n)"
 if ($ProvisionAllDemos -eq 'y') {
-       # Ensure the DEFAULT_LOCATION environment variable is set
-       if (-not $env:DEFAULT_LOCATION) {
-              $defaultLocation = Read-Host "Please enter the default location for your resources"
-              azd env set DEFAULT_LOCATION $defaultLocation
-       }
-
        # Intro
        azd env set INTRO_DEMO "true"
        if (-not $env:INTRO_RESOURCE_GROUP) {
@@ -48,10 +142,8 @@ if ($ProvisionAllDemos -eq 'y') {
               
               # Ensure the VISION_LOCATION environment variable is set
               if (-not $env:VISION_LOCATION) {
-                     $visionLocation = Read-Host "Please enter the location for your Vision resources"
-                     azd env set VISION_LOCATION $visionLocation
+                     Set-ResourceGroupLocation -envVarName "VISION_LOCATION" -resourceAlias "Vision" -availableRegions $availableRegions -defaultLocation $defaultLocation
               }
-
        }
 
        # Language
@@ -71,8 +163,7 @@ if ($ProvisionAllDemos -eq 'y') {
               
               # Ensure the AOAI_LOCATION environment variable is set
               if (-not $env:AOAI_LOCATION) {
-                     $aoaiLocation = Read-Host "Please enter the location for your Azure OpenAI resources"
-                     azd env set AOAI_LOCATION $aoaiLocation
+                     Set-ResourceGroupLocation -envVarName "AOAI_LOCATION" -resourceAlias "Azure OpenAI" -availableRegions $availableRegions -defaultLocation $defaultLocation
               }
        }
 
@@ -83,6 +174,7 @@ if ($ProvisionAllDemos -eq 'y') {
               $SearchResourceGroup = "search-${env:AZURE_ENV_NAME}-rg"
               azd env set SEARCH_RESOURCE_GROUP $SearchResourceGroup
        }
+       
        # Doc Intel
        azd env set DOCINTEL_DEMO "true"
        # Ensure the DOCINTEL_RESOURCE_GROUP environment variable is set
@@ -92,15 +184,12 @@ if ($ProvisionAllDemos -eq 'y') {
 
               # Ensure the DOCINTEL_LOCATION environment variable is set
               if (-not $env:DOCINTEL_LOCATION) {
-                     $docIntelLocation = Read-Host "Please enter the location for your Document Intelligence resources"
-                     azd env set DOCINTEL_LOCATION $docIntelLocation
+                     Set-ResourceGroupLocation -envVarName "DOCINTEL_LOCATION" -resourceAlias "Document Intelligence" -availableRegions $availableRegions -defaultLocation $defaultLocation
               }
        }
 }
 else {
-       # Ensure the DEFAULT_LOCATION environment variable is set
-       $defaultLocation = Read-Host "Please enter the default location for your resources"
-       azd env set DEFAULT_LOCATION $defaultLocation
+       # Provision only the selected demos
 
        # Ensure the INTRO_DEMO environment variable is set
        $IntroDemo = Read-Host "Provision Intro Demo? (y/n)"
@@ -127,8 +216,7 @@ else {
 
                      # Ensure the VISION_LOCATION environment variable is set
                      if (-not $env:VISION_LOCATION) {
-                            $visionLocation = Read-Host "Please enter the location for your Vision resources"
-                            azd env set VISION_LOCATION $visionLocation
+                            Set-ResourceGroupLocation -envVarName "VISION_LOCATION" -resourceAlias "Vision" -availableRegions $availableRegions -defaultLocation $defaultLocation
                      }
               }
        }
@@ -161,8 +249,7 @@ else {
 
                      # Ensure the AOAI_LOCATION environment variable is set
                      if (-not $env:AOAI_LOCATION) {
-                            $visionLocation = Read-Host "Please enter the location for your Azure OpenAI resources"
-                            azd env set AOAI_LOCATION $visionLocation
+                            Set-ResourceGroupLocation -envVarName "AOAI_LOCATION" -resourceAlias "Azure OpenAI" -availableRegions $availableRegions -defaultLocation $defaultLocation
                      }
               }
        }
@@ -195,8 +282,7 @@ else {
 
                      # Ensure the DOCINTEL_LOCATION environment variable is set
                      if (-not $env:DOCINTEL_LOCATION) {
-                            $docIntelLocation = Read-Host "Please enter the location for your Document Intelligence resources"
-                            azd env set DOCINTEL_LOCATION $docIntelLocation
+                            Set-ResourceGroupLocation -envVarName "DOCINTEL_LOCATION" -resourceAlias "Document Intelligence" -availableRegions $availableRegions -defaultLocation $defaultLocation
                      }
               }
        }


### PR DESCRIPTION
- Moved the setting of the DEFAULT_LOCATION outside of the "if ($ProvisionAllDemos -eq 'y')" clause since the same code was duplicated later, this way we have it only once, the variable is always used.
- Allowed for the setting of DEFAULT_LOCATION to read $env:AZURE_LOCATION and let the user use this by just pressing ENTER.
- If an Azure region/location is entered, it will be checked against a list of available regions that is populated in the beginning of the script.
- When asking for the locations/regions for other services, the DEFAULT_LOCATION value is used when ENTER is pressed and if the user wants to use any other region, this is checked against $availableRegions, too. For this a function Set-ResourceGroupLocation has been introduced, to remove the previous code duplication.
- The goal was to reduce typing by using the region selection during 'azd up' and to make sure the deployments don't fail because of a wrong or mistyped region.